### PR TITLE
Decouple likelihood execution strategy from sample method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *DS_Store
+
+# Julia files
+Manifest.toml

--- a/src/AffineInvariantMCMC.jl
+++ b/src/AffineInvariantMCMC.jl
@@ -13,13 +13,16 @@ const emceedir = splitdir(splitdir(pathof(AffineInvariantMCMC))[1])[1]
 
 include("likelihood.jl")
 
-"Test AffineInvariantMCMC"
+"""
+Test AffineInvariantMCMC
+"""
 function test()
 	include(joinpath(emceedir, "test", "runtests.jl"))
 end
 
 """
-Bayesian sampling using Goodman & Weare's Affine Invariant Markov chain Monte Carlo (MCMC) Ensemble sampler (aka Emcee)
+Bayesian sampling using Goodman & Weare's Affine Invariant Markov chain Monte Carlo (MCMC) Ensemble sampler (aka Emcee).
+The default implementation uses `RobustPmap` to evaluate the log-likelihood function in parallel.
 
 ```
 AffineInvariantMCMC.sample(llhood, numwalkers=10, numsamples_perwalker=100, thinning=1)
@@ -50,11 +53,11 @@ function sample(
 	a::Number=2.;
 	filename::AbstractString="",
 	load::Bool=true,
-	save::Bool=true;
+	save::Bool=true,
 	type::DataType=Float64,
-	checkoutputs::Bool=true
+	checkoutputs::Bool=true,
 )
-	return sample(LogLikelihoodFunction(llhood, RobustPmapExecKernel(; pmap_kwargs...)), numwalkers, x0, numsamples, thinning, a; filename, load, save, rng)
+	return sample(LogLikelihoodFunction(llhood, RobustPmapExecKernel(; type, checkoutputs)), numwalkers, x0, numsamples, thinning, a; filename, load, save, rng)
 end
 function sample(
 	llhood::LogLikelihoodFunction,
@@ -66,7 +69,7 @@ function sample(
 	filename::AbstractString="",
 	load::Bool=true,
 	save::Bool=true,
-	rng::Random.AbstractRNG=Random.GLOBAL_RNG
+	rng::Random.AbstractRNG=Random.GLOBAL_RNG,
 )
 	if numsamples_perwalker < 2
 		numsamples_perwalker = 2

--- a/src/AffineInvariantMCMC.jl
+++ b/src/AffineInvariantMCMC.jl
@@ -54,10 +54,11 @@ function sample(
 	filename::AbstractString="",
 	load::Bool=true,
 	save::Bool=true,
+	rng::Random.AbstractRNG=Random.GLOBAL_RNG,
 	type::DataType=Float64,
 	checkoutputs::Bool=true,
 )
-	return sample(LogLikelihoodFunction(llhood, RobustPmapExecKernel(; type, checkoutputs)), numwalkers, x0, numsamples, thinning, a; filename, load, save, rng)
+	return sample(LogLikelihoodFunction(llhood, RobustPmapExecKernel(; type, checkoutputs)), numwalkers, x0, numsamples_perwalker, thinning, a; filename, load, save, rng)
 end
 function sample(
 	llhood::LogLikelihoodFunction,

--- a/src/likelihood.jl
+++ b/src/likelihood.jl
@@ -1,0 +1,33 @@
+import RobustPmap
+
+abstract type ExecutionKernel end
+
+"""
+Execution kernel that evaluates a function in parallel using `RobustPmap`.
+"""
+Base.@kwdef struct RobustPmapExecKernel <: ExecutionKernel
+    type::Type
+    checkoutputs::Bool
+end
+
+(exec::RobustPmapExecKernel)(f::Function, xs::AbstractVector) = RobustPmap.rpmap(f, xs; t=exec.type, checkoutputs=exec.checkoutputs)
+
+"""
+Simple execution kernel which evaluates all samples serially. Only intended for testing.
+"""
+struct SerialExecKernel <: ExecutionKernel end
+
+(exec::SerialExecKernel)(f::Function, xs::AbstractVector) = map(f, xs)
+
+"""
+    LogLikelihoodFunction{funcType,execType<:ExecutionKernel}
+
+Wraps a log-likelihood function and a given `ExecutionKernel` which determines how the likelihood
+is evaluated over a batch of samples.
+"""
+struct LogLikelihoodFunction{funcType,execType<:ExecutionKernel}
+    f::funcType
+    exec::ExecutionKernel
+end
+
+(lik::LogLikelihoodFunction)(xs::Vector) = lik.exec(lik.f, xs)

--- a/src/likelihood.jl
+++ b/src/likelihood.jl
@@ -27,7 +27,7 @@ is evaluated over a batch of samples.
 """
 struct LogLikelihoodFunction{funcType,execType<:ExecutionKernel}
     f::funcType
-    exec::ExecutionKernel
+    exec::execType
 end
 
 (lik::LogLikelihoodFunction)(xs::Vector) = lik.exec(lik.f, xs)

--- a/src/likelihood.jl
+++ b/src/likelihood.jl
@@ -10,14 +10,14 @@ Base.@kwdef struct RobustPmapExecKernel <: ExecutionKernel
     checkoutputs::Bool
 end
 
-(exec::RobustPmapExecKernel)(f::Function, xs::AbstractVector) = RobustPmap.rpmap(f, xs; t=exec.type, checkoutputs=exec.checkoutputs)
+(exec::RobustPmapExecKernel)(f::Function, xs::AbstractArray) = RobustPmap.rpmap(f, xs; t=exec.type, checkoutputs=exec.checkoutputs)
 
 """
 Simple execution kernel which evaluates all samples serially. Only intended for testing.
 """
 struct SerialExecKernel <: ExecutionKernel end
 
-(exec::SerialExecKernel)(f::Function, xs::AbstractVector) = map(f, xs)
+(exec::SerialExecKernel)(f::Function, xs::AbstractArray) = map(f, xs)
 
 """
     LogLikelihoodFunction{funcType,execType<:ExecutionKernel}
@@ -30,4 +30,4 @@ struct LogLikelihoodFunction{funcType,execType<:ExecutionKernel}
     exec::execType
 end
 
-(lik::LogLikelihoodFunction)(xs::Vector) = lik.exec(lik.f, xs)
+(lik::LogLikelihoodFunction)(xs::AbstractArray) = lik.exec(lik.f, xs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,22 @@ burnin = 100
 	return flatchain, means, stds
 end
 
+Test.@testset "Serial execution" begin
+	stds = exp.(5 .* randn(numdims))
+	means = 1 .+ 5 .* rand(numdims)
+	llhood = x->begin
+		retval = 0.
+		for i = eachindex(x)
+			retval -= .5 * ((x[i] - means[i]) / stds[i]) ^ 2
+		end
+		return retval
+	end
+	x0 = rand(numdims, numwalkers) .* 10 .- 5
+	llhood = AffineInvariantMCMC.LogLikelihoodFunction(llhood, AffineInvariantMCMC.SerialExecKernel())
+	chain, llhoodvals = AffineInvariantMCMC.sample(llhood, numwalkers, x0, burnin, 1)
+	Test.@test all(isfinite.(llhoodvals))
+end
+
 Test.@testset "Emcee" begin
 	for _ in 1:10
 		flatchain, means, stds = testemcee()


### PR DESCRIPTION
There are use cases where the user may want to handle the parallelization of the likelihood on their own rather than have `pmap` called internally by `sample`. This is especially the case when the `llhood` function is complex and may itself involve function closures, compound types, etc. that do not interact well with nested calls to `pmap`.

This PR decouples the execution logic and allows the possibility for the user to implement their own `ExecutionKernel`.